### PR TITLE
Swap `onPreBuild` for `onPostBuild`

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "arrowParens": "avoid",
+  "printWidth": 100,
+  "semi": false,
+  "trailingComma": "none"
+}

--- a/index.js
+++ b/index.js
@@ -1,17 +1,12 @@
 // index.js
-const Parser = require("./lib/parser");
+const Parser = require("./lib/parser")
 
 module.exports = {
-  onPreBuild: async ({ utils, inputs }) => {
-    const parser = new Parser(
-      inputs.source,
-      inputs.destination,
-      inputs.defaultBranch,
-      utils
-    );
-    await parser.perform();
-    const stats = parser.stats();
-    console.log(stats.summary);
-    utils.status.show(stats);
-  },
-};
+  onPostBuild: async ({ utils, inputs }) => {
+    const parser = new Parser(inputs.source, inputs.destination, inputs.defaultBranch, utils)
+    await parser.perform()
+    const stats = parser.stats()
+    console.log(stats.summary)
+    utils.status.show(stats)
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helloample/netlify-plugin-redirects",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helloample/netlify-plugin-redirects",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "Read a CSV file, parse the rows and write them to `_redirects` _before_ Netlify processes your build.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I used this plugin and ran into a problem. It processed the `redirects.csv` file before the build and dropped the output into the `dist` directory. But the build wipes away the `dist` directory, so the file isn't there when the site is uploaded to the CDN.

I couldn't come up with any immediate downside to making this change, but I'm also guessing there was a reason it was `onPreBuild` previously.

If this isn't going to work, maybe we can make it configurable?

---

Sorry for the formatting, too. I have auto-formatting turned on for our other projects, so instead of fixing it, I put our typical `.prettierrc` file in place.